### PR TITLE
feat: Access Token 재발급 API 연결

### DIFF
--- a/app/src/main/java/com/project/meongcare/login/model/data/remote/LoginApi.kt
+++ b/app/src/main/java/com/project/meongcare/login/model/data/remote/LoginApi.kt
@@ -2,8 +2,11 @@ package com.project.meongcare.login.model.data.remote
 
 import com.project.meongcare.login.model.entities.LoginRequest
 import com.project.meongcare.login.model.entities.LoginResponse
+import com.project.meongcare.login.model.entities.ReissueResponse
 import retrofit2.Response
 import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.Header
 import retrofit2.http.POST
 
 interface LoginApi {
@@ -11,4 +14,9 @@ interface LoginApi {
     suspend fun postLoginInfo(
         @Body loginRequest: LoginRequest,
     ): Response<LoginResponse>
+
+    @GET("/auth/reissue")
+    suspend fun getNewAccessToken(
+        @Header("RefreshToken") refreshToken: String,
+    ): Response<ReissueResponse>
 }

--- a/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepository.kt
+++ b/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepository.kt
@@ -6,5 +6,6 @@ import com.project.meongcare.login.model.entities.ReissueResponse
 
 interface LoginRepository {
     suspend fun postLoginInfo(loginRequest: LoginRequest): LoginResponse?
+
     suspend fun getNewAccessToken(refreshToken: String): ReissueResponse?
 }

--- a/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepository.kt
+++ b/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepository.kt
@@ -2,7 +2,9 @@ package com.project.meongcare.login.model.data.repository
 
 import com.project.meongcare.login.model.entities.LoginRequest
 import com.project.meongcare.login.model.entities.LoginResponse
+import com.project.meongcare.login.model.entities.ReissueResponse
 
 interface LoginRepository {
     suspend fun postLoginInfo(loginRequest: LoginRequest): LoginResponse?
+    suspend fun getNewAccessToken(refreshToken: String): ReissueResponse?
 }

--- a/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepositoryImpl.kt
+++ b/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepositoryImpl.kt
@@ -41,4 +41,4 @@ class LoginRepositoryImpl
                 return null
             }
         }
-}
+    }

--- a/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepositoryImpl.kt
+++ b/app/src/main/java/com/project/meongcare/login/model/data/repository/LoginRepositoryImpl.kt
@@ -4,6 +4,7 @@ import android.util.Log
 import com.project.meongcare.login.model.data.remote.LoginRetrofitClient
 import com.project.meongcare.login.model.entities.LoginRequest
 import com.project.meongcare.login.model.entities.LoginResponse
+import com.project.meongcare.login.model.entities.ReissueResponse
 import javax.inject.Inject
 
 class LoginRepositoryImpl
@@ -13,11 +14,10 @@ class LoginRepositoryImpl
             try {
                 val response = loginRetrofitClient.loginApi.postLoginInfo(loginRequest)
                 if (response.isSuccessful) {
-                    Log.d("LoginRepository", "통신 성공 : accessToken - ${response.body()?.accessToken}")
+                    Log.d("LoginRepository", "통신 성공 : ${response.code()}")
                     return response.body()
                 } else {
-                    Log.d("LoginRepository", "통신 실패")
-                    Log.d("LoginRepository-fail", response.code().toString())
+                    Log.d("LoginRepository", "통신 실패 : ${response.code()}")
                     return null
                 }
             } catch (e: Exception) {
@@ -25,4 +25,20 @@ class LoginRepositoryImpl
                 return null
             }
         }
-    }
+
+        override suspend fun getNewAccessToken(refreshToken: String): ReissueResponse? {
+            try {
+                val response = loginRetrofitClient.loginApi.getNewAccessToken(refreshToken)
+                if (response.isSuccessful) {
+                    Log.d("LoginRepository", "통신 성공 : ${response.code()}")
+                    return response.body()
+                } else {
+                    Log.d("LoginRepository", "통신 실패 : ${response.code()}")
+                    return null
+                }
+            } catch (e: Exception) {
+                e.printStackTrace()
+                return null
+            }
+        }
+}

--- a/app/src/main/java/com/project/meongcare/login/model/entities/LoginResponse.kt
+++ b/app/src/main/java/com/project/meongcare/login/model/entities/LoginResponse.kt
@@ -4,3 +4,7 @@ data class LoginResponse(
     val accessToken: String,
     val refreshToken: String,
 )
+
+data class ReissueResponse(
+    val accessToken: String,
+)


### PR DESCRIPTION
access token 재발급 연결했습니다

사용하실 때 
LoginRepository 객체 생성하셔서 (Inject 어노테이션으로 의존성 주입 필요)
getNewAccessToken 함수에 현재 data store에 저장된 유저 refresh token 값 인자로 전달하시면 access token 재발급 됩니다!
재발급 된 access token은 UserPreferences(login>model>data>local 하위) 클래스 참고하셔서 새로 저장해주시면 됩니다